### PR TITLE
Improve coverage reports on coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,12 +98,14 @@ install:
   - make -j3
   - make check
   - mv src/.libs/*.gc* src
+  - ./proj -VC
 
 script:
   - echo "done"
 
 after_success:
-  - coveralls --extension .c
+# coveralls falsely reports .c-files in the build directories as having 100% coverage so we exclude them
+  - coveralls --extension .c --exclude build_autoconf --exclude build_cmake
   - echo "$TRAVIS_SECURE_ENV_VARS"
   - sh -c "./travis/build_docs.sh"
   - sh -c 'if test "$TRAVIS_SECURE_ENV_VARS" = "true" -a "$TRAVIS_BRANCH" = "master"; then echo "publish website"; ./travis/add_deploy_key.sh; ./travis/deploy_website.sh $TRAVIS_BUILD_DIR/docs/build /tmp; fi'


### PR DESCRIPTION
Added the new self-test in proj to the travis setup in order to get better coverage reports on coveralls. These are just the first steps, later on the self-tests should be added to the makefile as part of the existing test-suite.